### PR TITLE
Make header guard conformant to the C99 standard

### DIFF
--- a/latch.h
+++ b/latch.h
@@ -17,8 +17,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef __LATCH_H__
-#define __LATCH_H__
+#ifndef LATCH_H_
+#define LATCH_H_
 
 #include <time.h>
 
@@ -48,4 +48,4 @@ char* operationRemove(const char*);
 char* operationGet(const char*);
 char* operationsGet();
 
-#endif /* __LATCH_H__ */
+#endif /* LATCH_H_ */


### PR DESCRIPTION
The previously used header guard name (`__LATCH_H__`) is not conformant to the [C99 standard, section 7.1.3](https://busybox.net/~landley/c99-draft.html#7.1.3):

> 
> [...]
> 
> * All identifiers that begin with an underscore and either an uppercase letter or another underscore are always reserved for any use.
> 
> * [...]
> 

While this would normally be quite irrelevant (although still good to have), with the new [C++20 `latch` header](https://en.cppreference.com/w/cpp/header/latch) there is a good chance a collision between both header guards will eventually happen.

I have changed the header guard to `LATCH_H_` so that it does not contain any double underscore: [those are also reserved in C++](https://timsong-cpp.github.io/cppwp/n4659/lex.name).